### PR TITLE
fix: replace imgur links with github hosted images in raads-r

### DIFF
--- a/docs/incidents/raads-r.md
+++ b/docs/incidents/raads-r.md
@@ -17,61 +17,61 @@ https://embrace-autism.com/raads-r/#test
 
 | Name                                 | RAADS-R Autism Test Score               |
 |--------------------------------------|-----------------------------------------|
-| 🥇 vibe#0001                         | [240](https://i.imgur.com/mfp1KQh.png)  |
-| 🥈 ankh#8694                         | [234](https://i.imgur.com/BlpNzEE.png)  |
-| 🥉 shisueza#0232                     | [196](https://i.imgur.com/wwSCMcU.png)  |
-| Scrad#0685                           | [187](https://i.imgur.com/HWjPmAW.png)  |
-| Mawile#9390                          | [176](https://i.imgur.com/zImjGZc.png)  |
-| Pika-Pika-Penis#6981 (Pukito)        | [176](https://i.imgur.com/HHvPevc.png)  |
-| Jimbo#9153                           | [175](https://i.imgur.com/yLBGMX3.png)  |
-| pears#2760                           | [171](https://i.imgur.com/FNKjyMq.png)  |
-| Ril#4273                             | [171](https://i.imgur.com/b99TlDH.png)  |
-| smolkitten#6314                      | [167](https://i.imgur.com/vdPPgzD.png)  |
-| цареубийца#6150 (regicidio/scourge)  | [159](https://i.imgur.com/ppAaweC.png)  |
-| TechnoJo4#1337                       | [147](https://i.imgur.com/XPnbNiO.png)  |
-| Glitching Crow#7080                  | [147](https://i.imgur.com/9Bt7sQd.jpg)  |
-| Rakkun#5951                          | [139](https://i.imgur.com/W1nw7r1.png)  |
-| KangChan56#4861                      | [135](https://i.imgur.com/nNg0NfD.png)  |
-| intuol#6293                          | [134](https://i.imgur.com/FojvOIV.png)  |
-| BabyMikuChan#0101                    | [131](https://i.imgur.com/UHSI5Gy.png)  |
-| John Titor#4788                      | [120](https://i.imgur.com/ycsk36v.png)  |
-| DarkSwordsman#0001                   | [109](https://i.imgur.com/AKPqZwO.png)  |
-| SeaSmoke#0002                        | [108](https://i.imgur.com/m8FoA2x.jpg)  |
-| Pulkit200#2009                       | [092](https://i.imgur.com/PcOzNMr.png)  |
-| aro#1727                             | [090](https://i.imgur.com/RFM0ZiF.png)  |
-| ShoeChicken#6786                     | [090](https://i.imgur.com/7viWzzx.png)  |
-| cross#6727                           | [087](https://i.imgur.com/9ZlbjHj.png)  |
-| BlazingTruth#4044                    | [087](https://i.imgur.com/R6cGmKs.jpg)  |
-| Nish#6661                            | [085](https://i.imgur.com/vdu2sWM.jpg)  |
-| karma#7928                           | [083](https://i.imgur.com/IDFULX2.png)  |
-| ThaUnknown_#3951                     | [080](https://i.imgur.com/SmNgyJj.jpg)  |
-| guyman#4884                          | [078](https://i.imgur.com/ubtwPRA.png)  |
-| Problemsolver4ever#1559              | [071](https://i.imgur.com/59LneTq.png)  |
-| [REDACTED]#2110                      | [063](https://i.imgur.com/KG6YTps.png)  |
-| ashanti#8233                         | [063](https://i.imgur.com/TaUONHM.png)  |
-| homer#0845                           | [057](https://i.imgur.com/gfJ38IJ.png)  |
-| Vodes#6262                           | [057](https://i.imgur.com/AY6gKoL.png)  |
-| source#5843                          | [042](https://i.imgur.com/iKRstI3.png)  |
-| Nokination#2225                      | [041](https://i.imgur.com/8hQkgTH.png)  |
-| Legionaire#6645                      | [041](https://i.imgur.com/7Zi8bth.jpg)  |
-| V01#8183                             | [030](https://i.imgur.com/ytpX6hF.png)  |
-| SXX#0401                             | [028](https://i.imgur.com/XNj5yzh.png)  |
-| bankai_phonk#7658                    | [027](https://i.imgur.com/RgdzRrJ.png)  |
-| DankMemz#7979                        | [022](https://i.imgur.com/lSY1V6u.png)  |
-| RainingTerror#0365                   | [020](https://i.imgur.com/d6ZLZMA.png)  |
-| Naidu Bendi#7077                     | [018](https://i.imgur.com/ZnMP6Gi.png)  |
-| succ_#2864                           | [016](https://i.imgur.com/GwDK7Sx.png)  |
-| Raventric#6253                       | [015](https://i.imgur.com/WGW6vBr.png)  |
-| Godsgallows#9665                     | [013](https://i.imgur.com/FcATqxj.png)  |
-| CidReaper#6535                       | [009](https://i.imgur.com/Pq0wFg1.png)  |
-| Genesiss#0125                        | [007](https://i.imgur.com/3mEzYWf.png)  |
-| Mizz141(Schrödingers Autism)         | [006](https://i.imgur.com/Ui6lH3h.png) / [237](https://i.imgur.com/WNMDxzq.png)  |
+| 🥇 ankh#8694                         | [234](https://user-images.githubusercontent.com/130555117/234929337-7f711be2-4fc8-4c03-99f3-afd4b3ee6ab2.png)  |
+| 🥈 shisueza#0232                     | [196](https://user-images.githubusercontent.com/130555117/234929502-068923d3-6591-47ec-8e53-9ba4fb7381af.png)  |
+| 🥉 Scrad#0685                        | [187](https://user-images.githubusercontent.com/130555117/234929674-a428a240-cb96-4953-ae81-d1a5ff6e2ed8.png)  |
+| Mawile#9390                          | [176](https://user-images.githubusercontent.com/130555117/234930310-5aa1811d-c701-4329-8a5d-f5ee4664d320.png)  |
+| Pika-Pika-Penis#6981 (Pukito)        | [176](https://user-images.githubusercontent.com/130555117/234930530-d83bb5b7-d2bc-48a6-9022-338a0c7fe422.png)  |
+| Jimbo#9153                           | [175](https://user-images.githubusercontent.com/130555117/234935906-2b0b4ebe-6864-467d-83d2-36c96c68daaf.png)  |
+| pears#2760                           | [171](https://user-images.githubusercontent.com/130555117/234935344-9e612e5d-4e26-4703-80dc-943a386407a9.png)  |
+| Ril#4273                             | [171](https://user-images.githubusercontent.com/130555117/234935268-3c4e2c1a-e4f8-4da9-b1af-bae2daccb089.png)  |
+| smolkitten#6314                      | [167](https://user-images.githubusercontent.com/130555117/234935123-fcb2c94e-775a-4012-a206-2789d84d81ea.png)  |
+| цареубийца#6150 (regicidio/scourge)  | [159](https://user-images.githubusercontent.com/130555117/234934976-1a02f805-1254-43d9-8f11-a58d8d29c39b.png)  |
+| TechnoJo4#1337                       | [147](https://user-images.githubusercontent.com/130555117/234934904-df8a5b36-cf4b-4922-b218-55d99ac1557d.png)  |
+| Glitching Crow#7080                  | [147](https://user-images.githubusercontent.com/130555117/234934799-a148697e-1ebc-445c-9cf0-6b2d2ea8a8dc.png)  |
+| Rakkun#5951                          | [139](https://user-images.githubusercontent.com/130555117/234936557-d1b3ba08-8a27-43fb-aff9-8168aa050141.png)  |
+| KangChan56#4861                      | [135](https://user-images.githubusercontent.com/130555117/234936632-16e1aa50-9cb4-46bd-ae6c-a16e42aa6669.png)  |
+| intuol#6293                          | [134](https://user-images.githubusercontent.com/130555117/234936716-b4b49c6e-cc13-4a33-a4f2-d312e3ddd4eb.png)  |
+| BabyMikuChan#0101                    | [131](https://user-images.githubusercontent.com/130555117/234936819-f79275b3-fb49-43f5-9c3b-74e7c91dbbe0.png)  |
+| John Titor#4788                      | [120](https://user-images.githubusercontent.com/130555117/234937046-591ddefa-66d0-4278-bea6-2df06352ca67.png)  |
+| DarkSwordsman#0001                   | [109](https://user-images.githubusercontent.com/130555117/234928040-846a1e75-02a7-44bd-9547-537a0200e14d.png)  |
+| SeaSmoke#0002                        | [108](https://user-images.githubusercontent.com/130555117/234927726-7071a85e-9eb3-4e37-9677-588e78019cc3.png)  |
+| MXX#9683                             | [094](https://user-images.githubusercontent.com/130555117/234926558-9f6059d3-57fa-4332-b5f1-e3ab0c0fa867.png)  |
+| Pulkit200#2009                       | [092](https://user-images.githubusercontent.com/130555117/234937451-5936f99a-303d-4512-90e0-67f9f2baffdd.png)  |
+| aro#1727                             | [090](https://user-images.githubusercontent.com/130555117/234938198-157d8555-cc3f-421d-bb9c-82ed26e14a81.png)  |
+| ShoeChicken#6786                     | [090](https://user-images.githubusercontent.com/130555117/234938359-7adb7665-e42a-4a46-8020-67b61c197aa7.png)  |
+| cross#6727                           | [087](https://user-images.githubusercontent.com/130555117/234938721-dbe99bb9-4a5d-4270-bbd7-670efea58875.png)  |
+| BlazingTruth#4044                    | [087](https://user-images.githubusercontent.com/130555117/234938876-6492e516-3af3-48a9-91e8-0a819750972a.png)  |
+| Nish#6661                            | [085](https://user-images.githubusercontent.com/130555117/234939159-f5fa847e-b060-4281-b5ba-660fb978c7a4.png)  |
+| karma#7928                           | [083](https://user-images.githubusercontent.com/130555117/234939347-c3927cad-a3b3-4621-b8bf-1471e0b1ef52.png)  |
+| ThaUnknown_#3951                     | [080](https://user-images.githubusercontent.com/130555117/234939609-a6369263-fdb3-4a0d-9018-148833fafe1f.png)  |
+| guyman#4884                          | [078](https://user-images.githubusercontent.com/130555117/234945522-aef9224c-e2d7-4496-bd2c-f13f09deca74.png)  |
+| Problemsolver4ever#1559              | [071](https://user-images.githubusercontent.com/130555117/234945325-65a99cd2-3ae3-439c-947a-7daeb4ba0fd2.png)  |
+| [REDACTED]#2110                      | [063](https://user-images.githubusercontent.com/130555117/234945038-4ad12674-0156-46ca-b714-9f378cfc2359.png)  |
+| ashanti#8233                         | [063](https://user-images.githubusercontent.com/130555117/234944291-309e1061-e491-494f-b870-3f5a42d7481d.png)  |
+| homer#0845                           | [057](https://user-images.githubusercontent.com/130555117/234944061-c7e45a84-5d54-43f8-8d20-ef1ba4f67f30.png)  |
+| Vodes#6262                           | [057](https://user-images.githubusercontent.com/130555117/234943865-21ce97f6-7fec-45c9-96c1-ae4d6a41b5f2.png)  |
+| source#5843                          | [042](https://user-images.githubusercontent.com/130555117/234931110-a82ac30e-d5b5-42b1-bf2f-c45e1c3ca5bc.png)  |
+| Nokination#2225                      | [041](https://user-images.githubusercontent.com/130555117/234934099-0e7b6114-a7ec-45f1-b3b8-c44dafccacd3.png)  |
+| Legionaire#6645                      | [041](https://user-images.githubusercontent.com/130555117/234933982-e2e79c72-14e4-44b9-84d5-308846541453.png)  |
+| V01#8183                             | [030](https://user-images.githubusercontent.com/130555117/234933904-742dd30f-91c8-41ed-8c29-df7d5b00ec97.png)  |
+| SXX#0401                             | [028](https://user-images.githubusercontent.com/130555117/234933750-966022a5-8800-4c7d-8676-e35c20711dc5.png)  |
+| bankai_phonk#7658                    | [027](https://user-images.githubusercontent.com/130555117/234932757-3da10086-ef14-4a51-b69c-1dcd3a46c0b9.png)  |
+| DankMemz#7979                        | [022](https://user-images.githubusercontent.com/130555117/234932880-a7dceff5-05b9-458b-a6c4-b5f9ea6b6ad5.png)  |
+| RainingTerror#0365                   | [020](https://user-images.githubusercontent.com/130555117/234933039-edd6e0f2-88ed-4b97-8d56-bfc9868c9820.png)  |
+| Naidu Bendi#7077                     | [018](https://user-images.githubusercontent.com/130555117/234933434-a6a022db-2bf2-4c0f-b1aa-7794d577d28c.png)  |
+| succ_#2864                           | [016](https://user-images.githubusercontent.com/130555117/234932338-05898873-7d0d-4965-81a3-f158b4db5c9a.png)  |
+| Raventric#6253                       | [015](https://user-images.githubusercontent.com/130555117/234932242-f99787ef-727d-4f49-a734-03d35ccad49f.png)  |
+| Godsgallows#9665                     | [013](https://user-images.githubusercontent.com/130555117/234932114-339d8391-3588-4ebd-918c-afd0ecc6df2f.png)  |
+| CidReaper#6535                       | [009](https://user-images.githubusercontent.com/130555117/234932025-266aad04-b77c-4882-87bf-af394e9b7f3e.png)  |
+| Genesiss#0125                        | [007](https://user-images.githubusercontent.com/130555117/234931778-c4196814-f5e3-40ee-9786-0413926bf453.png)  |
+| Mizz141(Schrödingers Autism)         | [006](https://user-images.githubusercontent.com/130555117/234931256-e18c0707-1830-46f4-a9f4-de85c7e01b24.png) / [237](https://user-images.githubusercontent.com/130555117/234931461-9b5f0c58-b0ef-4973-a635-57c5ab6a2535.png)  |
 
 
-**Current Lowest: Genesiss#0125**
-**Current Highest: vibe#0001**
-**Average Score: 98.878**
-**Known Autistic Staff: Jimbo, Munch, Vibe**
+**Current Lowest: Genesiss#0125**  
+**Current Highest: ankh#8694**  
+**Average Score: 98.878**  
+**Known Autistic Staff: Jimbo, Munch**
 
 ## Super Autists
 


### PR DESCRIPTION
I have not changed the hyperlinks below the super autists and the average might need a fact check.