### PR TITLE
fix: replace imgur links with github hosted images in incidents/token-logging.md

### DIFF
--- a/docs/incidents/token-logging.md
+++ b/docs/incidents/token-logging.md
@@ -8,4 +8,4 @@ label: Token Logging
 
 [Marek's](/users/marek) token logging was first detected on August 3, 2022.  News quickly spread of mareks token logger and he was banned from other servers he was in (snackbox, seadex, etc..)
 
-![discord screenshot](https://i.imgur.com/gdthOky.jpg)
+![discord screenshot](https://user-images.githubusercontent.com/130555117/236004709-1e9c0c97-584a-4ed1-adde-d22be4786e1b.png)


### PR DESCRIPTION
Replaced imgur link with github hosted image, but the former screenshot has been changed with a new one that has a better image ratio